### PR TITLE
Create DatabaseHelperSQLite

### DIFF
--- a/app/src/main/java/uk/ucl/group21/currentviewapp/DatabaseHelperSQLite
+++ b/app/src/main/java/uk/ucl/group21/currentviewapp/DatabaseHelperSQLite
@@ -1,0 +1,28 @@
+package uk.ucl.group21.currentviewapp;
+
+import android.content.Context;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+
+/**
+ * Created by whsgemac on 30/11/2016.
+ */
+
+public class DatabaseHelperSQLite extends SQLiteOpenHelper{
+
+    public static final String DATABASE_NAME = "Clinician.db";
+
+    public DatabaseHelperSQLite(Context context, String name, SQLiteDatabase.CursorFactory factory, int version) {
+        super(context, name, factory, version);
+    }
+
+    @Override
+    public void onCreate(SQLiteDatabase sqLiteDatabase) {
+
+    }
+
+    @Override
+    public void onUpgrade(SQLiteDatabase sqLiteDatabase, int i, int i1) {
+
+    }
+}


### PR DESCRIPTION
Database Helper, DatabaseHelperSQLite, DatabaseMainActivity are files needed for the database creation (trail version now but it's working and can be merged with patient inf. page , and the page can be emulated)